### PR TITLE
Fix: UTC time offset problem

### DIFF
--- a/src/model/day.js
+++ b/src/model/day.js
@@ -2,7 +2,7 @@ import moment from 'moment/moment'
 
 export default class Day {
   constructor(data) {
-    this.MiladiTarihUzunIso8601 = data.MiladiTarihUzunIso8601
+    this.MiladiTarihKisa = data.MiladiTarihKisa
     //
     this.Imsak = this.convertToDate(data.Imsak)
     this.Gunes = this.convertToDate(data.Gunes)
@@ -14,7 +14,7 @@ export default class Day {
 
   convertToDate(hours) {
     const [hour, minutes] = hours.split(':')
-    return moment(this.MiladiTarihUzunIso8601)
+    return moment(this.MiladiTarihKisa, 'DD.MM.YYYY')
       .hour(hour)
       .minutes(minutes)
       .seconds(0)

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -11,13 +11,13 @@ export default {
   },
   today: state => {
     const day = state.times.find(o =>
-      moment(o.MiladiTarihUzunIso8601).isSame(moment(state.now), 'day')
+      moment(o.MiladiTarihKisa, 'DD.MM.YYYY').isSame(moment(state.now), 'day')
     )
     return day ? new Day(day) : null
   },
   tomorrow: state => {
     const day = state.times.find(o =>
-      moment(o.MiladiTarihUzunIso8601).isSame(
+      moment(o.MiladiTarihKisa, 'DD.MM.YYYY').isSame(
         moment(state.now).add(1, 'days'),
         'day'
       )


### PR DESCRIPTION
Diyanet islerinin sagladigi `MiladiTarihUzunIso8601` alani Turkiye'nin yerel saati ile gunun ilk saatini (`00:00`) donuyor (ornegin bugun icin: `2020-05-03T00:00:00+03:00`) . Bu alan icerisindeki `+03:00` olan UTC time offset bilgisi, `moment` kutuphanesi tarafindan parse edilirken UTC veya lokal zamana donusturuluyor ve karsilastirmalar bu zaman dilimi uzerinden yapiliyor. ([referans](https://momentjs.com/docs/#/parsing/parse-zone/))

Bu durum, UTC offset'i Turkiye'ninkinden daha dusuk olan (UTC ile saat farki daha az olan) ulkeler icin, (ornegin Ingiltere), parse edilen gunun bir onceki gun olmasina sebep oluyor. 

UTC+01:00 (Ingiltere yaz saati) icin bir ornek verirsek:
```
> moment.parse("2020-05-03T00:00:00+03:00").format()
2020-05-02T22:00:00+01:00
```

Bu sebeple, Turkiye'nin batisinda kalan ulkeler icin [su satirdaki](https://github.com/ademilter/prayer-times/blob/master/src/store/getters.js#L13) kiyaslama, icinde bulunulan gunden bir sonraki gunun degerini buluyor. 

Diyanet islerinin namaz vakitlerini her konumun kendi zaman dilimi ile hesaplayip, servisinde Turkiye zaman dilimi bunlari sagliyor. Burdaki tutarsizliktan oturu, `MiladiTarihUzunIso8601` alani yerine `MiladiTarihKisa` alaninin kullanilmasinin daha dogru oldugunu dusunuyorum. 