### PR TITLE
Improve overall design and add loading states

### DIFF
--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+export default function Loading() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className="mx-auto my-4 h-8 w-8"
+    >
+      <g stroke="currentColor">
+        <circle
+          cx="12"
+          cy="12"
+          r="9.5"
+          fill="none"
+          strokeLinecap="round"
+          strokeWidth="2"
+        >
+          <animate
+            attributeName="stroke-dasharray"
+            calcMode="spline"
+            dur="1.5s"
+            keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1"
+            keyTimes="0;0.475;0.95;1"
+            repeatCount="indefinite"
+            values="0 150;42 150;42 150;42 150"
+          />
+          <animate
+            attributeName="stroke-dashoffset"
+            calcMode="spline"
+            dur="1.5s"
+            keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1"
+            keyTimes="0;0.475;0.95;1"
+            repeatCount="indefinite"
+            values="0;-16;-59;-59"
+          />
+        </circle>
+        <animateTransform
+          attributeName="transform"
+          dur="2s"
+          repeatCount="indefinite"
+          type="rotate"
+          values="0 12 12;360 12 12"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -86,7 +86,7 @@ const SettingsList = ({
           <input
             type="text"
             autoFocus
-            className="w-full h-12 px-4 border rounded-lg"
+            className="w-full h-12 px-4 transition-colors border rounded-lg outline-none hover:border-zinc-300 focus:border-zinc-400"
             {...inputProps}
             value={q}
             onChange={e => setQ(e.target.value)}
@@ -99,7 +99,7 @@ const SettingsList = ({
           <button
             key={item.value}
             type="button"
-            className="flex items-center w-full h-12 px-4 transition-colors rounded-lg bg-zinc-100 hover:bg-zinc-200"
+            className="flex items-center w-full h-12 px-4 transition-colors border rounded-lg border-zinc-200 bg-zinc-50 hover:border-zinc-300 hover:bg-zinc-100"
             onClick={() => onChange(item.value)}
           >
             {item.label}

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import Fuse from "fuse.js";
+import { motion } from "framer-motion";
 import useTranslation from "next-translate/useTranslation";
 
 type Item = { value: string; label: string };
@@ -57,45 +58,47 @@ const SettingsList = ({
   }, [fuse, q, data, pushFirstData]);
 
   return (
-    <div className="">
-      <div className="sticky top-0 p-2 -mx-2 bg-white">
+    <div>
+      <motion.div
+        className="sticky top-0 p-2 -mx-2 bg-white"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
         {!backButtonProps?.hidden && (
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              className="flex items-center h-12 shrink-0"
-              onClick={() => router.back()}
-              {...backButtonProps}
+          <button
+            type="button"
+            className="flex items-center h-12 shrink-0"
+            onClick={() => router.back()}
+            {...backButtonProps}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                strokeWidth="1.5"
-                stroke="currentColor"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polyline points="15 6 9 12 15 18" />
-              </svg>
+              <polyline points="15 6 9 12 15 18" />
+            </svg>
 
-              <span>{backButtonText}</span>
-            </button>
-          </div>
+            <span>{backButtonText}</span>
+          </button>
         )}
-        <div>
-          <input
-            type="text"
-            autoFocus
-            className="w-full h-12 px-4 transition-colors border rounded-lg outline-none hover:border-zinc-300 focus:border-zinc-400"
-            {...inputProps}
-            value={q}
-            onChange={e => setQ(e.target.value)}
-          />
-        </div>
-      </div>
+
+        <input
+          type="text"
+          autoFocus
+          className="w-full h-12 px-4 transition-colors border rounded-lg outline-none hover:border-zinc-300 focus:border-zinc-400"
+          {...inputProps}
+          value={q}
+          onChange={e => setQ(e.target.value)}
+        />
+      </motion.div>
 
       <div className="space-y-1">
         {loading ? (

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -11,6 +11,7 @@ interface ISelect {
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   pushFirst?: string[];
   backButtonText?: string;
+  loading?: boolean;
   backButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
@@ -24,6 +25,7 @@ const SettingsList = ({
   data = [],
   inputProps = {},
   pushFirst = [],
+  loading = true,
   backButtonText = undefined,
   backButtonProps = undefined,
 }: ISelect) => {
@@ -78,6 +80,7 @@ const SettingsList = ({
               >
                 <polyline points="15 6 9 12 15 18" />
               </svg>
+
               <span>{backButtonText}</span>
             </button>
           </div>
@@ -95,16 +98,61 @@ const SettingsList = ({
       </div>
 
       <div className="space-y-1">
-        {results.map(item => (
-          <button
-            key={item.value}
-            type="button"
-            className="flex items-center w-full h-12 px-4 transition-colors border rounded-lg border-zinc-200 bg-zinc-50 hover:border-zinc-300 hover:bg-zinc-100"
-            onClick={() => onChange(item.value)}
+        {loading ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className="w-8 h-8 mx-auto my-4"
           >
-            {item.label}
-          </button>
-        ))}
+            <g stroke="currentColor">
+              <circle
+                cx="12"
+                cy="12"
+                r="9.5"
+                fill="none"
+                strokeLinecap="round"
+                strokeWidth="2"
+              >
+                <animate
+                  attributeName="stroke-dasharray"
+                  calcMode="spline"
+                  dur="1.5s"
+                  keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1"
+                  keyTimes="0;0.475;0.95;1"
+                  repeatCount="indefinite"
+                  values="0 150;42 150;42 150;42 150"
+                ></animate>
+                <animate
+                  attributeName="stroke-dashoffset"
+                  calcMode="spline"
+                  dur="1.5s"
+                  keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1"
+                  keyTimes="0;0.475;0.95;1"
+                  repeatCount="indefinite"
+                  values="0;-16;-59;-59"
+                ></animate>
+              </circle>
+              <animateTransform
+                attributeName="transform"
+                dur="2s"
+                repeatCount="indefinite"
+                type="rotate"
+                values="0 12 12;360 12 12"
+              ></animateTransform>
+            </g>
+          </svg>
+        ) : (
+          results.map(item => (
+            <button
+              key={item.value}
+              type="button"
+              className="flex items-center w-full h-12 px-4 transition-colors border rounded-lg border-zinc-200 bg-zinc-50 hover:border-zinc-300 hover:bg-zinc-100"
+              onClick={() => onChange(item.value)}
+            >
+              {item.label}
+            </button>
+          ))
+        )}
       </div>
     </div>
   );

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -50,12 +50,12 @@ const SettingsList = ({
 
   return (
     <div className="">
-      <div className="relative sticky top-0 -mx-2 bg-white p-2">
+      <div className="sticky top-0 p-2 -mx-2 bg-white">
         {!backButtonProps?.hidden && (
           <div className="flex items-center gap-1">
             <button
               type="button"
-              className="flex h-12 shrink-0 items-center"
+              className="flex items-center h-12 shrink-0"
               onClick={() => router.back()}
               {...backButtonProps}
             >
@@ -80,7 +80,7 @@ const SettingsList = ({
           <input
             type="text"
             autoFocus
-            className="h-12 w-full rounded-lg border px-4"
+            className="w-full h-12 px-4 border rounded-lg"
             {...inputProps}
             value={q}
             onChange={e => setQ(e.target.value)}
@@ -93,7 +93,7 @@ const SettingsList = ({
           <button
             key={item.value}
             type="button"
-            className="flex h-12 w-full items-center rounded-lg bg-zinc-100 px-4"
+            className="flex items-center w-full h-12 px-4 rounded-lg bg-zinc-100"
             onClick={() => onChange(item.value)}
           >
             {item.label}

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import Fuse from "fuse.js";
 import { motion } from "framer-motion";
 import useTranslation from "next-translate/useTranslation";
+import Loading from "@/components/loading";
 
 type Item = { value: string; label: string };
 
@@ -16,17 +17,12 @@ interface ISelect {
   backButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
-const options = {
-  keys: ["label"],
-  threshold: 0.5,
-};
-
 const SettingsList = ({
   onChange = () => {},
   data = [],
   inputProps = {},
   pushFirst = [],
-  loading = true,
+  loading = false,
   backButtonText = undefined,
   backButtonProps = undefined,
 }: ISelect) => {
@@ -37,8 +33,13 @@ const SettingsList = ({
 
   const [q, setQ] = useState<string>("");
 
+  const fuseOptions = {
+    keys: ["label"],
+    threshold: 0.5,
+  };
+
   const fuse = useMemo(() => {
-    return new Fuse(data, options);
+    return new Fuse(data, fuseOptions);
   }, [data]);
 
   const pushFirstData = useMemo(() => {
@@ -93,7 +94,7 @@ const SettingsList = ({
         <input
           type="text"
           autoFocus
-          className="h-12 w-full rounded-lg border px-4 outline-none transition-colors hover:border-zinc-300 focus:border-zinc-400"
+          className="h-12 w-full rounded-lg border px-4"
           {...inputProps}
           value={q}
           onChange={e => setQ(e.target.value)}
@@ -102,54 +103,13 @@ const SettingsList = ({
 
       <div className="space-y-1">
         {loading ? (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            className="mx-auto my-4 h-8 w-8"
-          >
-            <g stroke="currentColor">
-              <circle
-                cx="12"
-                cy="12"
-                r="9.5"
-                fill="none"
-                strokeLinecap="round"
-                strokeWidth="2"
-              >
-                <animate
-                  attributeName="stroke-dasharray"
-                  calcMode="spline"
-                  dur="1.5s"
-                  keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1"
-                  keyTimes="0;0.475;0.95;1"
-                  repeatCount="indefinite"
-                  values="0 150;42 150;42 150;42 150"
-                ></animate>
-                <animate
-                  attributeName="stroke-dashoffset"
-                  calcMode="spline"
-                  dur="1.5s"
-                  keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1"
-                  keyTimes="0;0.475;0.95;1"
-                  repeatCount="indefinite"
-                  values="0;-16;-59;-59"
-                ></animate>
-              </circle>
-              <animateTransform
-                attributeName="transform"
-                dur="2s"
-                repeatCount="indefinite"
-                type="rotate"
-                values="0 12 12;360 12 12"
-              ></animateTransform>
-            </g>
-          </svg>
+          <Loading />
         ) : (
           results.map(item => (
             <button
               key={item.value}
               type="button"
-              className="flex h-12 w-full items-center rounded-lg border border-zinc-200 bg-zinc-50 px-4 transition-colors hover:border-zinc-300 hover:bg-zinc-100"
+              className="flex h-12 w-full items-center rounded-lg bg-zinc-100 px-4"
               onClick={() => onChange(item.value)}
             >
               {item.label}

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -60,7 +60,7 @@ const SettingsList = ({
   return (
     <div>
       <motion.div
-        className="sticky top-0 p-2 -mx-2 bg-white"
+        className="sticky top-0 -mx-2 bg-white p-2"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -68,7 +68,7 @@ const SettingsList = ({
         {!backButtonProps?.hidden && (
           <button
             type="button"
-            className="flex items-center h-12 shrink-0"
+            className="flex h-12 shrink-0 items-center"
             onClick={() => router.back()}
             {...backButtonProps}
           >
@@ -93,7 +93,7 @@ const SettingsList = ({
         <input
           type="text"
           autoFocus
-          className="w-full h-12 px-4 transition-colors border rounded-lg outline-none hover:border-zinc-300 focus:border-zinc-400"
+          className="h-12 w-full rounded-lg border px-4 outline-none transition-colors hover:border-zinc-300 focus:border-zinc-400"
           {...inputProps}
           value={q}
           onChange={e => setQ(e.target.value)}
@@ -105,7 +105,7 @@ const SettingsList = ({
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
-            className="w-8 h-8 mx-auto my-4"
+            className="mx-auto my-4 h-8 w-8"
           >
             <g stroke="currentColor">
               <circle
@@ -149,7 +149,7 @@ const SettingsList = ({
             <button
               key={item.value}
               type="button"
-              className="flex items-center w-full h-12 px-4 transition-colors border rounded-lg border-zinc-200 bg-zinc-50 hover:border-zinc-300 hover:bg-zinc-100"
+              className="flex h-12 w-full items-center rounded-lg border border-zinc-200 bg-zinc-50 px-4 transition-colors hover:border-zinc-300 hover:bg-zinc-100"
               onClick={() => onChange(item.value)}
             >
               {item.label}

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -45,7 +45,13 @@ const SettingsList = ({
   }, [data, pushFirst]);
 
   const results = useMemo(() => {
-    return q ? fuse.search(q).map(o => o.item) : [...pushFirstData, ...data];
+    const removeFirstDataFromData = data.filter(
+      d => !pushFirstData.find(p => p.value === d.value)
+    );
+
+    return q
+      ? fuse.search(q).map(o => o.item)
+      : [...pushFirstData, ...removeFirstDataFromData];
   }, [fuse, q, data, pushFirstData]);
 
   return (

--- a/components/settings-list.tsx
+++ b/components/settings-list.tsx
@@ -99,7 +99,7 @@ const SettingsList = ({
           <button
             key={item.value}
             type="button"
-            className="flex items-center w-full h-12 px-4 rounded-lg bg-zinc-100"
+            className="flex items-center w-full h-12 px-4 transition-colors rounded-lg bg-zinc-100 hover:bg-zinc-200"
             onClick={() => onChange(item.value)}
           >
             {item.label}

--- a/components/time-list-row.tsx
+++ b/components/time-list-row.tsx
@@ -1,11 +1,10 @@
 import { TimeNames } from "@/lib/types";
 import Container from "@/components/container";
 import { motion } from "framer-motion";
-import { cx } from "@/lib/utils";
+import { cx, formattedTime } from "@/lib/utils";
 import { useContext } from "react";
 import { CommonStoreContext } from "@/stores/common";
 import useTranslation from "next-translate/useTranslation";
-import { formattedTime } from "@/lib/utils";
 
 export default function TimeListRow({
   time,
@@ -61,7 +60,7 @@ export default function TimeListRow({
         time === TimeNames.Yatsi && "pb-8 md:pb-14"
       )}
     >
-      <Container className={"flex h-full items-center px-2 py-2"}>
+      <Container className="flex h-full items-center px-2 py-2">
         <div className="relative flex h-full w-full items-center justify-between px-6 py-3 text-lg md:text-xl">
           {isTimeActive && (
             <motion.span

--- a/components/time-list-row.tsx
+++ b/components/time-list-row.tsx
@@ -23,7 +23,7 @@ export default function TimeListRow({
 
   const value = times?.today && times?.today?.[time];
 
-  const formattedValue = formattedTime(value, timeFormat);
+  const formattedValue = formattedTime(timeFormat, value);
 
   const now = times?.time?.now;
   const isTimeActive = now === time;
@@ -63,8 +63,7 @@ export default function TimeListRow({
     >
       <Container className={"flex h-full items-center px-2 py-2"}>
         <div
-          className="relative flex h-full w-full items-center justify-between
-        px-6 py-3 text-lg md:text-xl"
+          className="relative flex items-center justify-between w-full h-full px-6 py-3 text-lg md:text-xl"
         >
           {isTimeActive && (
             <motion.span
@@ -88,8 +87,8 @@ export default function TimeListRow({
               }}
             />
           )}
-          <h5 className="capitalize leading-none">{timeName}</h5>
-          <h4 className="tabular-nums leading-none">{formattedValue}</h4>
+          <h5 className="leading-none capitalize">{timeName}</h5>
+          <h4 className="leading-none tabular-nums">{formattedValue}</h4>
         </div>
       </Container>
     </motion.div>

--- a/components/time-list-row.tsx
+++ b/components/time-list-row.tsx
@@ -62,9 +62,7 @@ export default function TimeListRow({
       )}
     >
       <Container className={"flex h-full items-center px-2 py-2"}>
-        <div
-          className="relative flex items-center justify-between w-full h-full px-6 py-3 text-lg md:text-xl"
-        >
+        <div className="relative flex h-full w-full items-center justify-between px-6 py-3 text-lg md:text-xl">
           {isTimeActive && (
             <motion.span
               layoutId="border"
@@ -87,8 +85,8 @@ export default function TimeListRow({
               }}
             />
           )}
-          <h5 className="leading-none capitalize">{timeName}</h5>
-          <h4 className="leading-none tabular-nums">{formattedValue}</h4>
+          <h5 className="capitalize leading-none">{timeName}</h5>
+          <h4 className="tabular-nums leading-none">{formattedValue}</h4>
         </div>
       </Container>
     </motion.div>

--- a/components/time-summary-timer.tsx
+++ b/components/time-summary-timer.tsx
@@ -9,11 +9,7 @@ export default function TimeSummaryTimer() {
 
   const { timer, times } = useContext(CommonStoreContext);
 
-  const ValueComp = (props: HTMLAttributes<HTMLSpanElement>) => (
-    <b className="tabular-nums" {...props} />
-  );
-
-  let timeName = t(`times${times?.time.next as TimeNames}`)
+  let timeName = t(`times${times?.time.next as TimeNames}`);
   if (times?.today?.isJumuah && times?.time.next === TimeNames.Ogle) {
     timeName = t("timesJumuah");
   }
@@ -78,3 +74,7 @@ export default function TimeSummaryTimer() {
     </div>
   );
 }
+
+const ValueComp = (props: HTMLAttributes<HTMLSpanElement>) => (
+  <b className="tabular-nums" {...props} />
+);

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -111,22 +111,23 @@ export class Times {
     if (!this.today) return false;
 
     return (
-      this.localTime > DateTime.fromFormat(this.today[TimeNames.Imsak], "HH:mm")
+      this.localTime >
+      DateTime.fromFormat(this.today[TimeNames.Imsak], hourFormat)
     );
   }
 
   timer(): TypeTimer {
     if (!this.today || !this.tomorrow) return [0, 0, 0];
 
-    let dateTime = DateTime.fromFormat(this.today[this.time.next], "HH:mm");
+    let dateTime = DateTime.fromFormat(this.today[this.time.next], hourFormat);
 
     if (this.time.now === TimeNames.Yatsi) {
-      dateTime = DateTime.fromFormat(this.today[TimeNames.Imsak], "HH:mm");
+      dateTime = DateTime.fromFormat(this.today[TimeNames.Imsak], hourFormat);
 
       if (this.isBeforeMidnight()) {
         dateTime = DateTime.fromFormat(
           this.tomorrow[TimeNames.Imsak],
-          "HH:mm"
+          hourFormat
         ).plus({ days: 1 });
       }
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { TypeTimer } from "@/lib/types";
+import { TimeFormat, TypeTimer } from "@/lib/types";
 import { ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { DateTime } from "luxon";
@@ -23,7 +23,7 @@ export function adjustedTime(adjustment: number, time: string = "00:00") {
 }
 
 export function formattedTime(
-  timeFormat: "12" | "24",
+  timeFormat: TimeFormat,
   baseTime: string = "00:00"
 ) {
   return DateTime.fromFormat(baseTime, hourFormat)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,10 +9,6 @@ export function cx(...inputs: ClassValue[]): string {
 }
 
 export function secondSplit(second: number): TypeTimer {
-  let pad = (x: number): string => {
-    return x < 10 ? `0${x}` : `${x}`;
-  };
-
   return [
     Math.floor(second / 3600),
     Math.floor((second % 3600) / 60),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -20,15 +20,15 @@ export function secondSplit(second: number): TypeTimer {
   ];
 }
 
-export function adjustedTime(time: string = "00:00", adjustment: number) {
+export function adjustedTime(adjustment: number, time: string = "00:00") {
   const timeValue = DateTime.fromFormat(time, hourFormat);
   const newTime = timeValue.plus({ minutes: adjustment });
   return newTime.toFormat(hourFormat);
 }
 
 export function formattedTime(
-  baseTime: string = "00:00",
-  timeFormat: "12" | "24"
+  timeFormat: "12" | "24",
+  baseTime: string = "00:00"
 ) {
   return DateTime.fromFormat(baseTime, hourFormat)
     .toFormat(timeFormat === "12" ? hourFormat12 : hourFormat)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "next-translate-plugin": "^2.0.2",
     "postcss": "^8.4.21",
     "prettier": "^2.8.4",
-    "prettier-plugin-tailwindcss": "^0.2.2",
+    "prettier-plugin-tailwindcss": "^0.2.4",
     "tailwind-merge": "^1.10.0",
     "tailwindcss": "^3.2.6",
     "typescript": "^4.9.5"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,19 +1,11 @@
 import "@/styles/globals.css";
 
 import type { AppProps } from "next/app";
-// import { Inter } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import { CommonStoreProvider } from "@/stores/common";
 import Head from "next/head";
 import { metadata } from "@/lib/meta";
 import Layout from "@/components/layout";
-
-// const inter = Inter({
-//   variable: "--font-inter",
-//   display: "swap",
-//   style: "normal",
-//   subsets: ["latin-ext"],
-// });
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/pages/settings/adjust.tsx
+++ b/pages/settings/adjust.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import Container from "@/components/container";
 import useTranslation from "next-translate/useTranslation";
@@ -18,7 +18,10 @@ export default function Adjust() {
   const today = rawTimes?.today;
 
   const timeFormat = settings.timeFormat;
-  const adjustments = settings.adjustments ?? [0, 0, 0, 0, 0, 0];
+  const adjustments = useMemo(
+    () => settings.adjustments ?? [0, 0, 0, 0, 0, 0],
+    [settings.adjustments]
+  );
   const [dirtyIndexes, setDirtyIndexes] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
@@ -35,9 +38,9 @@ export default function Adjust() {
   const visualizeAdjustment = (i: number) => {
     let time = today?.[timeKeys[i]];
     if (dirtyIndexes[i]) {
-      time = adjustedTime(time, adjustments[i]);
+      time = adjustedTime(adjustments[i], time);
     }
-    return formattedTime(time, timeFormat);
+    return formattedTime(timeFormat, time);
   };
 
   const onChangeAdjustment = async (value: number, timeIndex: number) => {
@@ -75,16 +78,16 @@ export default function Adjust() {
           {isActive && (
             <button
               type="button"
-              className="flex h-8 w-8 items-center justify-center"
+              className="flex items-center justify-center w-8 h-8"
               onClick={() => onChangeAdjustment(0, i)}
             >
               {adjustments[i]}
             </button>
           )}
 
-          <span className="flex items-center rounded border border-zinc-200 bg-white">
+          <span className="flex items-center bg-white border rounded border-zinc-200">
             <button
-              className="flex h-8 w-8 items-center justify-center"
+              className="flex items-center justify-center w-8 h-8"
               type="button"
               onClick={() => onChangeAdjustment(adjustments[i] - 1, i)}
             >
@@ -102,7 +105,7 @@ export default function Adjust() {
               </svg>
             </button>
             <button
-              className="flex h-8 w-8 items-center justify-center border-l border-l-zinc-200"
+              className="flex items-center justify-center w-8 h-8 border-l border-l-zinc-200"
               type="button"
               onClick={() => onChangeAdjustment(adjustments[i] + 1, i)}
             >
@@ -127,13 +130,13 @@ export default function Adjust() {
   });
 
   return (
-    <Container className="flex min-h-full flex-col gap-6 py-10">
+    <Container className="flex flex-col min-h-full gap-6 py-10">
       <p>{t("settingsCustomAdjustmentsDetails")}</p>
 
-      <div className="grid rounded-lg border border-zinc-200">{Times}</div>
+      <div className="grid border rounded-lg border-zinc-200">{Times}</div>
 
       <button
-        className="mt-auto flex h-12 w-full items-center justify-center rounded-lg border bg-current px-4"
+        className="flex items-center justify-center w-full h-12 px-4 mt-auto bg-current border rounded-lg"
         onClick={() => onSaveAdjustments()}
       >
         <span className="text-white">{t("settingsSave")}</span>

--- a/pages/settings/adjust.tsx
+++ b/pages/settings/adjust.tsx
@@ -65,7 +65,7 @@ export default function Adjust() {
       <div
         key={`time${i}`}
         className={cx(
-          "flex items-center border-b bg-zinc-50 px-4 py-3 first:rounded-t-lg last:rounded-b-lg last:border-0",
+          " flex items-center border-b bg-zinc-50 px-4 py-3 first:rounded-t-lg last:rounded-b-lg last:border-0",
           isActive && "bg-white"
         )}
       >
@@ -78,16 +78,16 @@ export default function Adjust() {
           {isActive && (
             <button
               type="button"
-              className="flex items-center justify-center w-8 h-8"
+              className="flex h-8 w-8 items-center justify-center"
               onClick={() => onChangeAdjustment(0, i)}
             >
               {adjustments[i]}
             </button>
           )}
 
-          <span className="flex items-center bg-white border rounded border-zinc-200">
+          <span className="flex items-center rounded border border-zinc-200 bg-white">
             <button
-              className="flex items-center justify-center w-8 h-8"
+              className="flex h-8 w-8 items-center justify-center"
               type="button"
               onClick={() => onChangeAdjustment(adjustments[i] - 1, i)}
             >
@@ -105,7 +105,7 @@ export default function Adjust() {
               </svg>
             </button>
             <button
-              className="flex items-center justify-center w-8 h-8 border-l border-l-zinc-200"
+              className="flex h-8 w-8 items-center justify-center border-l border-l-zinc-200"
               type="button"
               onClick={() => onChangeAdjustment(adjustments[i] + 1, i)}
             >
@@ -130,13 +130,13 @@ export default function Adjust() {
   });
 
   return (
-    <Container className="flex flex-col min-h-full gap-6 py-10">
+    <Container className="flex min-h-full flex-col gap-6 py-10">
       <p>{t("settingsCustomAdjustmentsDetails")}</p>
 
-      <div className="grid border rounded-lg border-zinc-200">{Times}</div>
+      <div className="grid rounded-lg border border-zinc-200">{Times}</div>
 
       <button
-        className="flex items-center justify-center w-full h-12 px-4 mt-auto bg-current border rounded-lg"
+        className="mt-auto flex h-12 w-full items-center justify-center rounded-lg border bg-current px-4"
         onClick={() => onSaveAdjustments()}
       >
         <span className="text-white">{t("settingsSave")}</span>

--- a/pages/settings/adjust.tsx
+++ b/pages/settings/adjust.tsx
@@ -4,7 +4,7 @@ import Container from "@/components/container";
 import useTranslation from "next-translate/useTranslation";
 import { CommonStoreContext } from "@/stores/common";
 import { TimeNames } from "@/lib/types";
-import { formattedTime, cx, adjustedTime } from "@/lib/utils";
+import { adjustedTime, cx, formattedTime } from "@/lib/utils";
 
 const timeKeys = Object.values(TimeNames);
 
@@ -65,7 +65,7 @@ export default function Adjust() {
       <div
         key={`time${i}`}
         className={cx(
-          " flex items-center border-b bg-zinc-50 px-4 py-3 first:rounded-t-lg last:rounded-b-lg last:border-0",
+          "flex items-center border-b bg-zinc-50 px-4 py-3 first:rounded-t-lg last:rounded-b-lg last:border-0",
           isActive && "bg-white"
         )}
       >

--- a/pages/settings/city.tsx
+++ b/pages/settings/city.tsx
@@ -14,7 +14,7 @@ export default function Country() {
     useContext(CommonStoreContext);
 
   const [data, setData] = useState<ICity[]>([]);
-  const [_, setLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const fetchCityData = useCallback(async () => {
     try {
@@ -41,31 +41,30 @@ export default function Country() {
 
   return (
     <Container className="py-6">
-      {data.length > 0 && (
-        <SettingsList
-          inputProps={{
-            placeholder: t("settingsSearchCity"),
-            name: "city",
-          }}
-          onChange={async id => {
-            const city = data.find(o => o.IlceID === id) as ICity;
+      <SettingsList
+        inputProps={{
+          placeholder: t("settingsSearchCity"),
+          name: "city",
+        }}
+        onChange={async id => {
+          const city = data.find(o => o.IlceID === id) as ICity;
 
-            setSettings({
-              ...settings,
-              country: _settings.country,
-              region: _settings.region,
-              city,
-            });
+          setSettings({
+            ...settings,
+            country: _settings.country,
+            region: _settings.region,
+            city,
+          });
 
-            await fetchData(city.IlceID);
-            await push(`/`);
-          }}
-          data={data.map(c => ({
-            value: c.IlceID,
-            label: c[t("settingsCityKey") as keyof ICity],
-          }))}
-        />
-      )}
+          await fetchData(city.IlceID);
+          await push(`/`);
+        }}
+        loading={loading}
+        data={data.map(c => ({
+          value: c.IlceID,
+          label: c[t("settingsCityKey") as keyof ICity],
+        }))}
+      />
     </Container>
   );
 }

--- a/pages/settings/city.tsx
+++ b/pages/settings/city.tsx
@@ -16,7 +16,7 @@ export default function Country() {
   const [data, setData] = useState<ICity[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const fetchCityData = useCallback(async () => {
+  const fetchCities = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -36,8 +36,8 @@ export default function Country() {
 
   useEffect(() => {
     if (!_settings.region) return;
-    fetchCityData();
-  }, [_settings, fetchCityData]);
+    fetchCities();
+  }, [_settings, fetchCities]);
 
   return (
     <Container className="py-6">

--- a/pages/settings/city.tsx
+++ b/pages/settings/city.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import Container from "@/components/container";
 import useTranslation from "next-translate/useTranslation";
 import SettingsList from "@/components/settings-list";
-import { ICity, IRegion } from "@/lib/types";
+import { ICity } from "@/lib/types";
 import { useRouter } from "next/router";
 import { CommonStoreContext } from "@/stores/common";
 
@@ -14,9 +14,9 @@ export default function Country() {
     useContext(CommonStoreContext);
 
   const [data, setData] = useState<ICity[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [_, setLoading] = useState(false);
 
-  const fetchData1 = async () => {
+  const fetchCityData = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -32,12 +32,12 @@ export default function Country() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [_settings.region?.SehirID]);
 
   useEffect(() => {
     if (!_settings.region) return;
-    fetchData1();
-  }, [_settings]);
+    fetchCityData();
+  }, [_settings, fetchCityData]);
 
   return (
     <Container className="py-6">
@@ -58,7 +58,6 @@ export default function Country() {
             });
 
             await fetchData(city.IlceID);
-
             await push(`/`);
           }}
           data={data.map(c => ({

--- a/pages/settings/country.tsx
+++ b/pages/settings/country.tsx
@@ -15,7 +15,7 @@ export default function Country() {
   const [data, setData] = useState<ICountry[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const fetchData = async () => {
+  const fetchCountries = async () => {
     try {
       setLoading(true);
 
@@ -33,7 +33,7 @@ export default function Country() {
   };
 
   useEffect(() => {
-    fetchData();
+    fetchCountries();
   }, []);
 
   return (

--- a/pages/settings/country.tsx
+++ b/pages/settings/country.tsx
@@ -13,7 +13,7 @@ export default function Country() {
   const { _settings, _setSettings } = useContext(CommonStoreContext);
 
   const [data, setData] = useState<ICountry[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [_, setLoading] = useState(false);
 
   const fetchData = async () => {
     try {

--- a/pages/settings/country.tsx
+++ b/pages/settings/country.tsx
@@ -13,7 +13,7 @@ export default function Country() {
   const { _settings, _setSettings } = useContext(CommonStoreContext);
 
   const [data, setData] = useState<ICountry[]>([]);
-  const [_, setLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const fetchData = async () => {
     try {
@@ -26,7 +26,7 @@ export default function Country() {
 
       setData(data);
     } catch (error) {
-      console.log(error);
+      console.error(error);
     } finally {
       setLoading(false);
     }
@@ -53,6 +53,7 @@ export default function Country() {
           value: c.UlkeID,
           label: c[t("settingsCountryKey") as keyof ICountry],
         }))}
+        loading={loading}
         backButtonProps={{
           hidden: true,
         }}

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -33,18 +33,18 @@ export default function Settings() {
   };
 
   const onChangeTimeFormat = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    await setSettings({
+    setSettings({
       ...settings,
       timeFormat: e.target.value as typeof settings.timeFormat,
     });
   };
 
   return (
-    <Container className="flex min-h-full flex-col gap-6 py-10">
+    <Container className="flex flex-col min-h-full gap-6 py-10">
       <div className="grid gap-6">
         <Link
           href="/settings/country"
-          className="flex rounded-lg border border-zinc-200 p-4 hover:bg-blue-50"
+          className="flex p-4 border rounded-lg border-zinc-200 hover:bg-blue-50"
         >
           <div className="grow">
             <h5 className="">{t("settingsCurrentLocation")}</h5>
@@ -57,7 +57,7 @@ export default function Settings() {
             </div>
           </div>
 
-          <span className="flex h-full w-10 shrink-0 items-center justify-center opacity-60">
+          <span className="flex items-center justify-center w-10 h-full shrink-0 opacity-60">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -75,7 +75,7 @@ export default function Settings() {
           </span>
         </Link>
 
-        <div className="flex items-center gap-px rounded-lg border border-zinc-200 bg-zinc-200 bg-zinc-200">
+        <div className="flex items-center gap-px border rounded-lg border-zinc-200 bg-zinc-200">
           <SettingsItem
             isSelected={lang === "tr"}
             name="lang"
@@ -96,7 +96,7 @@ export default function Settings() {
           </SettingsItem>
         </div>
 
-        <div className="flex items-center gap-px rounded-lg border border-zinc-200 bg-zinc-200 bg-zinc-200">
+        <div className="flex items-center gap-px border rounded-lg border-zinc-200 bg-zinc-200">
           <SettingsItem
             isSelected={timeFormat === TimeFormat.Twelve}
             name="timeFormat"
@@ -119,19 +119,19 @@ export default function Settings() {
 
         <Link
           href="/settings/adjust"
-          className="flex items-center gap-px rounded-lg border border-zinc-200 bg-zinc-200 bg-zinc-200"
+          className="flex items-center gap-px border rounded-lg border-zinc-200 bg-zinc-200"
         >
-          <label className="flex h-12 grow cursor-pointer items-center gap-2 rounded-lg bg-white px-4 hover:bg-blue-50">
+          <label className="flex items-center h-12 gap-2 px-4 bg-white rounded-lg cursor-pointer grow hover:bg-blue-50">
             <span className="grow">{t("settingsCustomAdjustments")}</span>
             <span className="">{adjustmentsAsText()}</span>
           </label>
         </Link>
 
-        <div className="space-y-px rounded-lg border border-zinc-200 bg-zinc-200">
+        <div className="space-y-px border rounded-lg border-zinc-200 bg-zinc-200">
           <a
             href="https://github.com/ademilter/vakitler"
             target="_blank"
-            className="flex items-center rounded-t-lg bg-white p-4 hover:bg-blue-50"
+            className="flex items-center p-4 bg-white rounded-t-lg hover:bg-blue-50"
           >
             <div className="grow">
               <p className="">{t("settingsOpenSource")}</p>
@@ -140,7 +140,7 @@ export default function Settings() {
               </p>
             </div>
 
-            <span className="flex h-full w-10 shrink-0 items-center justify-center opacity-80">
+            <span className="flex items-center justify-center w-10 h-full shrink-0 opacity-80">
               <svg
                 aria-hidden="true"
                 viewBox="0 0 16 16"
@@ -158,7 +158,7 @@ export default function Settings() {
           <a
             href="https://www.buymeacoffee.com/ademilter"
             target="_blank"
-            className="flex items-center rounded-b-lg bg-white p-4 hover:bg-blue-50"
+            className="flex items-center p-4 bg-white rounded-b-lg hover:bg-blue-50"
           >
             <div className="grow">
               <p className="">{t("settingsSourceCode")}</p>
@@ -167,7 +167,7 @@ export default function Settings() {
               </p>
             </div>
 
-            <span className="flex h-full w-10 shrink-0 items-center justify-center opacity-80">
+            <span className="flex items-center justify-center w-10 h-full shrink-0 opacity-80">
               <svg
                 width="20"
                 viewBox="0 0 884 1279"
@@ -190,7 +190,7 @@ export default function Settings() {
 
       <Link
         href="/"
-        className="mt-auto flex h-12 w-full items-center justify-center rounded-lg bg-current px-4"
+        className="flex items-center justify-center w-full h-12 px-4 mt-auto bg-current rounded-lg"
       >
         <span className="text-white">{t("settingsSave")}</span>
       </Link>

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -40,11 +40,11 @@ export default function Settings() {
   };
 
   return (
-    <Container className="flex flex-col min-h-full gap-6 py-10">
+    <Container className="flex min-h-full flex-col gap-6 py-10">
       <div className="grid gap-6">
         <Link
           href="/settings/country"
-          className="flex p-4 border rounded-lg border-zinc-200 hover:bg-blue-50"
+          className="flex rounded-lg border border-zinc-200 p-4 hover:bg-blue-50"
         >
           <div className="grow">
             <h5 className="">{t("settingsCurrentLocation")}</h5>
@@ -57,7 +57,7 @@ export default function Settings() {
             </div>
           </div>
 
-          <span className="flex items-center justify-center w-10 h-full shrink-0 opacity-60">
+          <span className="flex h-full w-10 shrink-0 items-center justify-center opacity-60">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -75,7 +75,7 @@ export default function Settings() {
           </span>
         </Link>
 
-        <div className="flex items-center gap-px border rounded-lg border-zinc-200 bg-zinc-200">
+        <div className="flex items-center gap-px rounded-lg border border-zinc-200 bg-zinc-200">
           <SettingsItem
             isSelected={lang === "tr"}
             name="lang"
@@ -96,7 +96,7 @@ export default function Settings() {
           </SettingsItem>
         </div>
 
-        <div className="flex items-center gap-px border rounded-lg border-zinc-200 bg-zinc-200">
+        <div className="flex items-center gap-px rounded-lg border border-zinc-200 bg-zinc-200">
           <SettingsItem
             isSelected={timeFormat === TimeFormat.Twelve}
             name="timeFormat"
@@ -119,19 +119,19 @@ export default function Settings() {
 
         <Link
           href="/settings/adjust"
-          className="flex items-center gap-px border rounded-lg border-zinc-200 bg-zinc-200"
+          className="flex items-center gap-px rounded-lg border border-zinc-200 bg-zinc-200"
         >
-          <label className="flex items-center h-12 gap-2 px-4 bg-white rounded-lg cursor-pointer grow hover:bg-blue-50">
+          <label className="flex h-12 grow cursor-pointer items-center gap-2 rounded-lg bg-white px-4 hover:bg-blue-50">
             <span className="grow">{t("settingsCustomAdjustments")}</span>
             <span className="">{adjustmentsAsText()}</span>
           </label>
         </Link>
 
-        <div className="space-y-px border rounded-lg border-zinc-200 bg-zinc-200">
+        <div className="space-y-px rounded-lg border border-zinc-200 bg-zinc-200">
           <a
             href="https://github.com/ademilter/vakitler"
             target="_blank"
-            className="flex items-center p-4 bg-white rounded-t-lg hover:bg-blue-50"
+            className="flex items-center rounded-t-lg bg-white p-4 hover:bg-blue-50"
           >
             <div className="grow">
               <p className="">{t("settingsOpenSource")}</p>
@@ -140,7 +140,7 @@ export default function Settings() {
               </p>
             </div>
 
-            <span className="flex items-center justify-center w-10 h-full shrink-0 opacity-80">
+            <span className="flex h-full w-10 shrink-0 items-center justify-center opacity-80">
               <svg
                 aria-hidden="true"
                 viewBox="0 0 16 16"
@@ -158,7 +158,7 @@ export default function Settings() {
           <a
             href="https://www.buymeacoffee.com/ademilter"
             target="_blank"
-            className="flex items-center p-4 bg-white rounded-b-lg hover:bg-blue-50"
+            className="flex items-center rounded-b-lg bg-white p-4 hover:bg-blue-50"
           >
             <div className="grow">
               <p className="">{t("settingsSourceCode")}</p>
@@ -167,7 +167,7 @@ export default function Settings() {
               </p>
             </div>
 
-            <span className="flex items-center justify-center w-10 h-full shrink-0 opacity-80">
+            <span className="flex h-full w-10 shrink-0 items-center justify-center opacity-80">
               <svg
                 width="20"
                 viewBox="0 0 884 1279"
@@ -190,7 +190,7 @@ export default function Settings() {
 
       <Link
         href="/"
-        className="flex items-center justify-center w-full h-12 px-4 mt-auto bg-current rounded-lg"
+        className="mt-auto flex h-12 w-full items-center justify-center rounded-lg bg-current px-4"
       >
         <span className="text-white">{t("settingsSave")}</span>
       </Link>

--- a/pages/settings/region.tsx
+++ b/pages/settings/region.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import Container from "@/components/container";
 import useTranslation from "next-translate/useTranslation";
 import SettingsList from "@/components/settings-list";
@@ -13,9 +13,9 @@ export default function Country() {
   const { _settings, _setSettings } = useContext(CommonStoreContext);
 
   const [data, setData] = useState<IRegion[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [_, setLoading] = useState(false);
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -27,16 +27,16 @@ export default function Country() {
 
       setData(data);
     } catch (error) {
-      console.log(error);
+      console.error(error);
     } finally {
       setLoading(false);
     }
-  };
+  }, [_settings.country?.UlkeID]);
 
   useEffect(() => {
     if (!_settings.country) return;
     fetchData();
-  }, [_settings]);
+  }, [_settings, fetchData]);
 
   return (
     <Container className="py-6">

--- a/pages/settings/region.tsx
+++ b/pages/settings/region.tsx
@@ -15,7 +15,7 @@ export default function Country() {
   const [data, setData] = useState<IRegion[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const fetchData = useCallback(async () => {
+  const fetchRegionData = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -35,8 +35,8 @@ export default function Country() {
 
   useEffect(() => {
     if (!_settings.country) return;
-    fetchData();
-  }, [_settings, fetchData]);
+    fetchRegionData();
+  }, [_settings, fetchRegionData]);
 
   return (
     <Container className="py-6">

--- a/pages/settings/region.tsx
+++ b/pages/settings/region.tsx
@@ -13,7 +13,7 @@ export default function Country() {
   const { _settings, _setSettings } = useContext(CommonStoreContext);
 
   const [data, setData] = useState<IRegion[]>([]);
-  const [_, setLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const fetchData = useCallback(async () => {
     try {
@@ -40,24 +40,23 @@ export default function Country() {
 
   return (
     <Container className="py-6">
-      {data.length > 0 && (
-        <SettingsList
-          inputProps={{
-            placeholder: t("settingsSearchRegion"),
-            name: "region",
-          }}
-          pushFirst={["539", "506"]}
-          onChange={id => {
-            const region = data.find(o => o.SehirID === id);
-            _setSettings({ ..._settings, region });
-            push(`/settings/city`);
-          }}
-          data={data.map(c => ({
-            value: c.SehirID,
-            label: c[t("settingsRegionKey") as keyof IRegion],
-          }))}
-        />
-      )}
+      <SettingsList
+        inputProps={{
+          placeholder: t("settingsSearchRegion"),
+          name: "region",
+        }}
+        pushFirst={["539", "506"]}
+        onChange={id => {
+          const region = data.find(o => o.SehirID === id);
+          _setSettings({ ..._settings, region });
+          push(`/settings/city`);
+        }}
+        loading={loading}
+        data={data.map(c => ({
+          value: c.SehirID,
+          label: c[t("settingsRegionKey") as keyof IRegion],
+        }))}
+      />
     </Container>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  scrollbar-gutter: stable;
+}
+
 @layer base {
   button {
     @apply text-left;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-html {
-  scrollbar-gutter: stable;
-}
-
 @layer base {
   button {
     @apply text-left;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,10 +1925,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-plugin-tailwindcss@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.3.tgz#b68a1de10056fc84055426af132c2697bea0955c"
-  integrity sha512-s2N5Dh7Ao5KTV1mao5ZBnn8EKtUcDPJEkGViZIjI0Ij9TTI5zgTz4IHOxW33jOdjHKa8CSjM88scelUiC5TNRQ==
+prettier-plugin-tailwindcss@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.4.tgz#ed0ca759bc948eb2bc48b419c6e57eb2adabdb0a"
+  integrity sha512-wMyugRI2yD8gqmMpZSS8kTA0gGeKozX/R+w8iWE+yiCZL09zY0SvfiHfHabNhjGhzxlQ2S2VuTxPE3T72vppCQ==
 
 prettier@^2.8.4:
   version "2.8.4"


### PR DESCRIPTION
Changes:

- ✅ Remove `pushFirstData` items from actual `data` list since it resulted in duplicates in the list.
- ✅ Add `scrollbar-gutter` CSS rule to `html` prevent layout shifting in setting lists.
- ✅ Use a tricky `framer-motion` fade animation to achieve _smooth-like_ transition of the backButton's visibility.
- ✅ Make use of `loading` states in country-region-city selection to show a spinner.
- ✅ Add border and hover state styles to settings list items.
- 🔧 Use `useCallback` hook to prevent unwanted re-renders due to inline function.
- 🔧 Removed `data.length > 0` condition since it was blocking page render (resulting in ugly transition between pages).
- 💡 Removed unused variable `pad` (did you forget to implement it?).
- 💡 Put default values at the end as per [`typescript:S1788`](https://rules.sonarsource.com/javascript/RSPEC-1788) rule.

Here's a preview:

![vakitler-update](https://user-images.githubusercontent.com/13917975/224511645-137d9e1a-6da3-4955-909b-97d692303b07.gif)
