### PR TITLE
feat: locale for time format

### DIFF
--- a/components/time-list-row.tsx
+++ b/components/time-list-row.tsx
@@ -13,7 +13,7 @@ export default function TimeListRow({
   time: TimeNames;
   index: number;
 }) {
-  const { t } = useTranslation("common");
+  const { t, lang } = useTranslation("common");
 
   const {
     times,
@@ -22,7 +22,7 @@ export default function TimeListRow({
 
   const value = times?.today && times?.today?.[time];
 
-  const formattedValue = formattedTime(timeFormat, value);
+  const formattedValue = formattedTime(value, timeFormat, lang);
 
   const now = times?.time?.now;
   const isTimeActive = now === time;

--- a/components/time-list-row.tsx
+++ b/components/time-list-row.tsx
@@ -22,7 +22,7 @@ export default function TimeListRow({
 
   const value = times?.today && times?.today?.[time];
 
-  const formattedValue = formattedTime(value, timeFormat, lang);
+  const formattedValue = formattedTime(timeFormat, value, lang);
 
   const now = times?.time?.now;
   const isTimeActive = now === time;

--- a/lib/const.ts
+++ b/lib/const.ts
@@ -1,5 +1,5 @@
 export const hourFormat = "HH:mm";
-export const hourFormat12 = "hh:mm a";
+export const hourFormat12 = "h:mm a";
 
 export const LOCAL_KEYS = {
   Settings: "VAKITLER_SETTINGS",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,8 +23,8 @@ export function adjustedTime(adjustment: number, time: string = "00:00") {
 }
 
 export function formattedTime(
+  timeFormat: TimeFormat,
   baseTime: string = "00:00",
-  timeFormat: "12" | "24",
   locale?: string
 ) {
   return DateTime.fromFormat(baseTime, hourFormat)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,10 +23,11 @@ export function adjustedTime(adjustment: number, time: string = "00:00") {
 }
 
 export function formattedTime(
-  timeFormat: TimeFormat,
-  baseTime: string = "00:00"
+  baseTime: string = "00:00",
+  timeFormat: "12" | "24",
+  locale?: string
 ) {
   return DateTime.fromFormat(baseTime, hourFormat)
-    .toFormat(timeFormat === "12" ? hourFormat12 : hourFormat)
+    .toFormat(timeFormat === "12" ? hourFormat12 : hourFormat, { locale })
     .toLowerCase();
 }

--- a/pages/settings/adjust.tsx
+++ b/pages/settings/adjust.tsx
@@ -9,7 +9,7 @@ import { adjustedTime, cx, formattedTime } from "@/lib/utils";
 const timeKeys = Object.values(TimeNames);
 
 export default function Adjust() {
-  const { t } = useTranslation("common");
+  const { t, lang } = useTranslation("common");
   const router = useRouter();
 
   const { settings, rawTimes, setSettings, fetchData } =
@@ -40,7 +40,7 @@ export default function Adjust() {
     if (dirtyIndexes[i]) {
       time = adjustedTime(adjustments[i], time);
     }
-    return formattedTime(timeFormat, time);
+    return formattedTime(time, timeFormat, lang);
   };
 
   const onChangeAdjustment = async (value: number, timeIndex: number) => {

--- a/pages/settings/adjust.tsx
+++ b/pages/settings/adjust.tsx
@@ -40,7 +40,7 @@ export default function Adjust() {
     if (dirtyIndexes[i]) {
       time = adjustedTime(adjustments[i], time);
     }
-    return formattedTime(time, timeFormat, lang);
+    return formattedTime(timeFormat, time, lang);
   };
 
   const onChangeAdjustment = async (value: number, timeIndex: number) => {


### PR DESCRIPTION
Güncel durumda 12h format seçiminde saat, dil ayarından bağımsız olarak "am" veya "pm" şeklinde yani İngilizce diline göre gösteriliyor. Dil ayarına bağlı gösterilmesi için küçük bir değişiklik yaptım.

Güncel durum [tr]:
<img width="457" alt="Screenshot 2023-03-13 at 21 05 50" src="https://user-images.githubusercontent.com/8572957/224833911-aee424cc-c2e2-4361-aee4-ec39750fb802.png">

Değişiklik sonrası [tr]:
<img width="460" alt="Screenshot 2023-03-13 at 21 05 23" src="https://user-images.githubusercontent.com/8572957/224833966-1a8857bf-a1c3-4997-bb90-3d26eabb6daa.png">

