### PR TITLE
🐞 fix: fixes date formating issue in android devices

### DIFF
--- a/components/time-summary-icon.tsx
+++ b/components/time-summary-icon.tsx
@@ -6,13 +6,26 @@ import { motion } from "framer-motion";
 import { DateTime } from "luxon";
 import { TimeNames } from "@/lib/types";
 import { HOUR_FORMAT } from "@/lib/const";
+import { toHijri, toGregorian } from "hijri-converter";
 
 export default function TimeSummaryIcon() {
-  const { lang } = useTranslation("common");
+  const { t } = useTranslation("common");
 
   const { times, themeColor } = useContext(CommonStoreContext);
   const localTime = times?.localTime || DateTime.local();
-
+  const hijriMonths = [
+    "Muharrem",
+    "Safer",
+    "Rebiulevvel",
+    "Rebiulahir",
+    "Cemaziyelevvel",
+    "Cemaziyelahir",
+    "Recep",
+    "Saban",
+    "Ramazan",
+    "Sevval",
+    "Zilkade",
+  ];
   // hicri takvimde akşam ezanı ile tarih bir sonraki güne geçer
   const isAksam =
     times?.today &&
@@ -31,6 +44,16 @@ export default function TimeSummaryIcon() {
   }, []);
 
   if (!times?.today) return null;
+
+  const hijriDate = toHijri(
+    localTime.year,
+    localTime.month,
+    localTime.day + (isAksam ? 1 : 0)
+  );
+
+  const formattedHijriDate = `${hijriDate.hd} ${t(
+    hijriMonths[hijriDate.hm - 1]
+  )} ${hijriDate.hy}`;
 
   return (
     <motion.button
@@ -52,9 +75,7 @@ export default function TimeSummaryIcon() {
           },
         }}
       >
-        {localTime
-          .reconfigure({ outputCalendar: isAksam ? "islamic" : "islamicc" })
-          .toLocaleString(DateTime.DATE_FULL, { locale: lang })}
+        {formattedHijriDate}
       </motion.span>
 
       <motion.span

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -14,5 +14,17 @@
   "regionKey": "SehirAdiEn",
   "cityKey": "IlceAdiEn",
   "back": "Back",
-  "save": "Save"
+  "save": "Save",
+  "Muharrem": "Muharram",
+  "Safer": "Safar",
+  "Rebiulevvel": "Rabi al-Awwal",
+  "Rebiulahir": "Rabi al-Thani",
+  "Cemaziyelevvel": "Jumada al-Awwal",
+  "Cemaziyelahir": "Jumada al-Thani",
+  "Recep": "Rajab",
+  "Saban": "Shaban",
+  "Ramazan": "Ramadan",
+  "Sevval": "Shawwal",
+  "Zilkade": "Dhu al-Qadah",
+  "Zilhicce": "Dhu al-Hijjah"
 }

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -14,5 +14,17 @@
   "regionKey": "SehirAdi",
   "cityKey": "IlceAdi",
   "back": "Geri",
-  "save": "Kaydet"
+  "save": "Kaydet",
+  "Muharrem": "Muharrem",
+  "Safer": "Safer",
+  "Rebiulevvel": "Rebiülevvel",
+  "Rebiulahir": "Rebiülahir",
+  "Cemaziyelevvel": "Cemaziyelevvel",
+  "Cemaziyelahir": "Cemaziyelahir",
+  "Recep": "Recep",
+  "Saban": "Şaban",
+  "Ramazan": "Ramazan",
+  "Sevval": "Şevval",
+  "Zilkade": "Zilkade",
+  "Zilhicce": "Zilhicce"
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clsx": "^1.2.1",
     "framer-motion": "^10.0.1",
     "fuse.js": "^6.6.2",
+    "hijri-converter": "^1.1.1",
     "luxon": "^3.2.1",
     "next": "^13.2.1",
     "next-pwa": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,6 +2592,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hijri-converter@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/hijri-converter/-/hijri-converter-1.1.1.tgz#5a0c6930ab3d1aaceb6d402464cc8710309748b9"
+  integrity sha512-uY2oDZllg7wcgvY7rdrM1VUE5iEqNjKGtrBUJlzniAsY73FuC5mb0kzdqLE/bU9Q50Iwhn6b9/Udw8SUIXHlhQ==
+
 idb@^7.0.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.1.tgz#d910ded866d32c7ced9befc5bfdf36f572ced72b"


### PR DESCRIPTION
 #70 fixed.  [Int.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) fonksiyonun Android'de İslam takvimleri için yanlış çalışıyor.Luxon kütüphanesi bu fonksiyonu kullandığından, Luxon yapılandırması üzerinden sorunu çözmek mümkün olmadı. Bunun yerine, tarihi Hicri takvime dönüştüren basit bir kütüphane ekleyerek ve gerekli formatı manuel olarak tanımlayarak sorunu çözdüm.

![image](https://user-images.githubusercontent.com/57873472/228712019-f650f6fb-2c07-45f9-a052-a6d5ae65ed41.png)
