### PR TITLE
FIX: Seçili şehrin saat dilimine göre geçerli namaz vakti gösterilir

### DIFF
--- a/model/times.ts
+++ b/model/times.ts
@@ -1,6 +1,6 @@
 import { DateTime, Interval, Settings } from "luxon";
 import { ITime, TimeNames, TypeTimer } from "@/types";
-import { secondSplit } from "@/utils/helper";
+import { secondSplit, numberToTimezoneOffset } from "@/utils/helper";
 import { HOUR_FORMAT } from "@/utils/const";
 import { Time } from "./time";
 
@@ -11,17 +11,16 @@ export class Times {
   public localTime: DateTime;
   public timeTravel: [number, number, number];
   public adjustments: number[];
-  public utcOffset: number;
 
   constructor(
     data: ITime[] = [],
     adjustments: number[] = timeNames.map(() => 0)
   ) {
-    Settings.defaultZone = "UTC";
     this.adjustments = adjustments;
-    this.utcOffset = data[0].GreenwichOrtalamaZamani;
+    const timeZone = data[0].GreenwichOrtalamaZamani;
+    Settings.defaultZone = numberToTimezoneOffset(timeZone);
     this.times = data.map(day => new Time(day));
-    this.localTime = DateTime.local().plus({ hours: this.utcOffset });
+    this.localTime = DateTime.local();
     this.timeTravel = [0, 0, 0];
     if (adjustments.some(a => a !== 0)) {
       this.adjustTimes(adjustments);
@@ -43,7 +42,7 @@ export class Times {
   }
 
   updateDateTime(datetime: DateTime): void {
-    this.localTime = datetime.plus({ hours: this.utcOffset });
+    this.localTime = datetime;
   }
 
   get today(): undefined | Time {

--- a/model/times.ts
+++ b/model/times.ts
@@ -122,12 +122,12 @@ export class Times {
     let dateTime = DateTime.fromFormat(this.today[this.time.next], HOUR_FORMAT, { zone: "UTC" })
 
     if (this.time.now === TimeNames.Yatsi) {
-      dateTime = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT);
+      dateTime = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT, { zone: "UTC" });
 
       if (this.isBeforeMidnight()) {
         dateTime = DateTime.fromFormat(
           this.tomorrow[TimeNames.Imsak],
-          HOUR_FORMAT
+          HOUR_FORMAT, { zone: "UTC" }
         ).plus({ days: 1 });
       }
     }

--- a/model/times.ts
+++ b/model/times.ts
@@ -70,12 +70,12 @@ export class Times {
     // TODO: check if today is undefined
     if (!this.today) return { now: TimeNames.Imsak, next: TimeNames.Imsak };
 
-    const Imsak = DateTime.fromFormat(this.today[TimeNames.Imsak],HOUR_FORMAT, { zone: "UTC" });
-    const Gunes = DateTime.fromFormat(this.today[TimeNames.Gunes],HOUR_FORMAT, { zone: "UTC" });
+    const Imsak = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT, { zone: "UTC" });
+    const Gunes = DateTime.fromFormat(this.today[TimeNames.Gunes], HOUR_FORMAT, { zone: "UTC" });
     const Ogle = DateTime.fromFormat(this.today[TimeNames.Ogle], HOUR_FORMAT, { zone: "UTC" });
     const Ikindi = DateTime.fromFormat(this.today[TimeNames.Ikindi], HOUR_FORMAT, { zone: "UTC" });
     const Aksam = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT, { zone: "UTC" });
-    const Yatsi = DateTime.fromFormat(this.today[TimeNames.Yatsi],HOUR_FORMAT, { zone: "UTC" });
+    const Yatsi = DateTime.fromFormat(this.today[TimeNames.Yatsi], HOUR_FORMAT, { zone: "UTC" });
 
     // default values = Isha
     const obj: { now: TimeNames; next: TimeNames } = {

--- a/model/times.ts
+++ b/model/times.ts
@@ -1,4 +1,4 @@
-import { DateTime, Interval } from "luxon";
+import { DateTime, Interval, Settings } from "luxon";
 import { ITime, TimeNames, TypeTimer } from "@/types";
 import { secondSplit } from "@/utils/helper";
 import { HOUR_FORMAT } from "@/utils/const";
@@ -17,10 +17,11 @@ export class Times {
     data: ITime[] = [],
     adjustments: number[] = timeNames.map(() => 0)
   ) {
+    Settings.defaultZone = "UTC+0";
     this.adjustments = adjustments;
     this.utcOffset = data[0].GreenwichOrtalamaZamani;
     this.times = data.map(day => new Time(day));
-    this.localTime = DateTime.utc().plus({ hours: this.utcOffset });
+    this.localTime = DateTime.local().plus({ hours: this.utcOffset });
     this.timeTravel = [0, 0, 0];
     if (adjustments.some(a => a !== 0)) {
       this.adjustTimes(adjustments);
@@ -70,12 +71,12 @@ export class Times {
     // TODO: check if today is undefined
     if (!this.today) return { now: TimeNames.Imsak, next: TimeNames.Imsak };
 
-    const Imsak = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT, { zone: "UTC" });
-    const Gunes = DateTime.fromFormat(this.today[TimeNames.Gunes], HOUR_FORMAT, { zone: "UTC" });
-    const Ogle = DateTime.fromFormat(this.today[TimeNames.Ogle], HOUR_FORMAT, { zone: "UTC" });
-    const Ikindi = DateTime.fromFormat(this.today[TimeNames.Ikindi], HOUR_FORMAT, { zone: "UTC" });
-    const Aksam = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT, { zone: "UTC" });
-    const Yatsi = DateTime.fromFormat(this.today[TimeNames.Yatsi], HOUR_FORMAT, { zone: "UTC" });
+    const Imsak = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT);
+    const Gunes = DateTime.fromFormat(this.today[TimeNames.Gunes], HOUR_FORMAT);
+    const Ogle = DateTime.fromFormat(this.today[TimeNames.Ogle], HOUR_FORMAT);
+    const Ikindi = DateTime.fromFormat(this.today[TimeNames.Ikindi], HOUR_FORMAT);
+    const Aksam = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT);
+    const Yatsi = DateTime.fromFormat(this.today[TimeNames.Yatsi], HOUR_FORMAT);
 
     // default values = Isha
     const obj: { now: TimeNames; next: TimeNames } = {
@@ -119,15 +120,15 @@ export class Times {
   timer(): TypeTimer {
     if (!this.today || !this.tomorrow) return [0, 0, 0];
 
-    let dateTime = DateTime.fromFormat(this.today[this.time.next], HOUR_FORMAT, { zone: "UTC" })
+    let dateTime = DateTime.fromFormat(this.today[this.time.next], HOUR_FORMAT);
 
     if (this.time.now === TimeNames.Yatsi) {
-      dateTime = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT, { zone: "UTC" });
+      dateTime = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT);
 
       if (this.isBeforeMidnight()) {
         dateTime = DateTime.fromFormat(
           this.tomorrow[TimeNames.Imsak],
-          HOUR_FORMAT, { zone: "UTC" }
+          HOUR_FORMAT
         ).plus({ days: 1 });
       }
     }
@@ -140,7 +141,7 @@ export class Times {
   timerRamadan(): TypeTimer {
     if (!this.today || !this.tomorrow) return [0, 0, 0];
 
-    let dateTime = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT, { zone: "UTC" })
+    let dateTime = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT);
 
     if ([TimeNames.Aksam, TimeNames.Yatsi].includes(this.time.now)) {
       dateTime = DateTime.fromFormat(

--- a/model/times.ts
+++ b/model/times.ts
@@ -11,14 +11,16 @@ export class Times {
   public localTime: DateTime;
   public timeTravel: [number, number, number];
   public adjustments: number[];
+  public utcOffset: number;
 
   constructor(
     data: ITime[] = [],
     adjustments: number[] = timeNames.map(() => 0)
   ) {
     this.adjustments = adjustments;
+    this.utcOffset = data[0].GreenwichOrtalamaZamani;
     this.times = data.map(day => new Time(day));
-    this.localTime = DateTime.local();
+    this.localTime = DateTime.utc().plus({ hours: this.utcOffset });
     this.timeTravel = [0, 0, 0];
     if (adjustments.some(a => a !== 0)) {
       this.adjustTimes(adjustments);
@@ -40,7 +42,7 @@ export class Times {
   }
 
   updateDateTime(datetime: DateTime): void {
-    this.localTime = datetime;
+    this.localTime = datetime.plus({ hours: this.utcOffset });
   }
 
   get today(): undefined | Time {
@@ -68,15 +70,12 @@ export class Times {
     // TODO: check if today is undefined
     if (!this.today) return { now: TimeNames.Imsak, next: TimeNames.Imsak };
 
-    const Imsak = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT);
-    const Gunes = DateTime.fromFormat(this.today[TimeNames.Gunes], HOUR_FORMAT);
-    const Ogle = DateTime.fromFormat(this.today[TimeNames.Ogle], HOUR_FORMAT);
-    const Ikindi = DateTime.fromFormat(
-      this.today[TimeNames.Ikindi],
-      HOUR_FORMAT
-    );
-    const Aksam = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT);
-    const Yatsi = DateTime.fromFormat(this.today[TimeNames.Yatsi], HOUR_FORMAT);
+    const Imsak = DateTime.fromFormat(this.today[TimeNames.Imsak],HOUR_FORMAT, { zone: "UTC" });
+    const Gunes = DateTime.fromFormat(this.today[TimeNames.Gunes],HOUR_FORMAT, { zone: "UTC" });
+    const Ogle = DateTime.fromFormat(this.today[TimeNames.Ogle], HOUR_FORMAT, { zone: "UTC" });
+    const Ikindi = DateTime.fromFormat(this.today[TimeNames.Ikindi], HOUR_FORMAT, { zone: "UTC" });
+    const Aksam = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT, { zone: "UTC" });
+    const Yatsi = DateTime.fromFormat(this.today[TimeNames.Yatsi],HOUR_FORMAT, { zone: "UTC" });
 
     // default values = Isha
     const obj: { now: TimeNames; next: TimeNames } = {
@@ -120,7 +119,7 @@ export class Times {
   timer(): TypeTimer {
     if (!this.today || !this.tomorrow) return [0, 0, 0];
 
-    let dateTime = DateTime.fromFormat(this.today[this.time.next], HOUR_FORMAT);
+    let dateTime = DateTime.fromFormat(this.today[this.time.next], HOUR_FORMAT, { zone: "UTC" })
 
     if (this.time.now === TimeNames.Yatsi) {
       dateTime = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT);
@@ -141,10 +140,7 @@ export class Times {
   timerRamadan(): TypeTimer {
     if (!this.today || !this.tomorrow) return [0, 0, 0];
 
-    let dateTime = DateTime.fromFormat(
-      this.today[TimeNames.Aksam],
-      HOUR_FORMAT
-    );
+    let dateTime = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT, { zone: "UTC" })
 
     if ([TimeNames.Aksam, TimeNames.Yatsi].includes(this.time.now)) {
       dateTime = DateTime.fromFormat(

--- a/model/times.ts
+++ b/model/times.ts
@@ -17,7 +17,7 @@ export class Times {
     data: ITime[] = [],
     adjustments: number[] = timeNames.map(() => 0)
   ) {
-    Settings.defaultZone = "UTC+0";
+    Settings.defaultZone = "UTC";
     this.adjustments = adjustments;
     this.utcOffset = data[0].GreenwichOrtalamaZamani;
     this.times = data.map(day => new Time(day));

--- a/model/times.ts
+++ b/model/times.ts
@@ -1,6 +1,6 @@
 import { DateTime, Interval, Settings } from "luxon";
 import { ITime, TimeNames, TypeTimer } from "@/types";
-import { secondSplit, numberToTimezoneOffset } from "@/utils/helper";
+import { secondSplit, numberToUTCOffset } from "@/utils/helper";
 import { HOUR_FORMAT } from "@/utils/const";
 import { Time } from "./time";
 
@@ -17,8 +17,8 @@ export class Times {
     adjustments: number[] = timeNames.map(() => 0)
   ) {
     this.adjustments = adjustments;
-    const timeZone = data[0].GreenwichOrtalamaZamani;
-    Settings.defaultZone = numberToTimezoneOffset(timeZone);
+    const timeOffset = data[0].GreenwichOrtalamaZamani;
+    Settings.defaultZone = numberToUTCOffset(timeOffset);
     this.times = data.map(day => new Time(day));
     this.localTime = DateTime.local();
     this.timeTravel = [0, 0, 0];

--- a/model/times.ts
+++ b/model/times.ts
@@ -73,7 +73,10 @@ export class Times {
     const Imsak = DateTime.fromFormat(this.today[TimeNames.Imsak], HOUR_FORMAT);
     const Gunes = DateTime.fromFormat(this.today[TimeNames.Gunes], HOUR_FORMAT);
     const Ogle = DateTime.fromFormat(this.today[TimeNames.Ogle], HOUR_FORMAT);
-    const Ikindi = DateTime.fromFormat(this.today[TimeNames.Ikindi], HOUR_FORMAT);
+    const Ikindi = DateTime.fromFormat(
+      this.today[TimeNames.Ikindi],
+      HOUR_FORMAT
+    );
     const Aksam = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT);
     const Yatsi = DateTime.fromFormat(this.today[TimeNames.Yatsi], HOUR_FORMAT);
 
@@ -140,7 +143,10 @@ export class Times {
   timerRamadan(): TypeTimer {
     if (!this.today || !this.tomorrow) return [0, 0, 0];
 
-    let dateTime = DateTime.fromFormat(this.today[TimeNames.Aksam], HOUR_FORMAT);
+    let dateTime = DateTime.fromFormat(
+      this.today[TimeNames.Aksam],
+      HOUR_FORMAT
+    );
 
     if ([TimeNames.Aksam, TimeNames.Yatsi].includes(this.time.now)) {
       dateTime = DateTime.fromFormat(

--- a/stores/common.tsx
+++ b/stores/common.tsx
@@ -199,7 +199,7 @@ export function CommonStoreProvider({ children }: { children: ReactNode }) {
 
   useInterval(
     () => {
-      let localTime = DateTime.utc()
+      let localTime = DateTime.local()
 
       const timeTravel = times!.timeTravel ?? [0, 0, 0];
       const hasChange = timeTravel.some((value: number) => value !== 0);

--- a/stores/common.tsx
+++ b/stores/common.tsx
@@ -199,7 +199,7 @@ export function CommonStoreProvider({ children }: { children: ReactNode }) {
 
   useInterval(
     () => {
-      let localTime = DateTime.local()
+      let localTime = DateTime.local();
 
       const timeTravel = times!.timeTravel ?? [0, 0, 0];
       const hasChange = timeTravel.some((value: number) => value !== 0);

--- a/stores/common.tsx
+++ b/stores/common.tsx
@@ -199,7 +199,7 @@ export function CommonStoreProvider({ children }: { children: ReactNode }) {
 
   useInterval(
     () => {
-      let localTime = DateTime.local();
+      let localTime = DateTime.utc()
 
       const timeTravel = times!.timeTravel ?? [0, 0, 0];
       const hasChange = timeTravel.some((value: number) => value !== 0);

--- a/types/index.ts
+++ b/types/index.ts
@@ -36,6 +36,7 @@ export interface ITime {
   HicriTarihUzun: string; // "8 Şaban 1444";
   MiladiTarihKisa: string; // "28.02.2023";
   AyinSekliURL: string; // ""http://namazvakti.diyanet.gov.tr/images/i7.gif"";
+  GreenwichOrtalamaZamani: number;
 }
 
 export enum TimeNames {

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -32,14 +32,16 @@ export function formattedTime(
     .toLowerCase();
 }
 
-export function numberToTimezoneOffset(offset: number): string {
+export function numberToUTCOffset(offset: number): string {
   const offsetHours = Math.floor(offset);
   const offsetMinutes = Math.round((offset - offsetHours) * 60);
 
   const sign = offset >= 0 ? "+" : "-";
 
-  const hoursString = Math.abs(offsetHours).toString().padStart(2, "0");
-  const minutesString = Math.abs(offsetMinutes).toString().padStart(2, "0");
+  const format = (value: number) => Math.abs(value).toString().padStart(2, "0");
+
+  const hoursString = format(offsetHours);
+  const minutesString = format(offsetMinutes);
 
   return `UTC${sign}${hoursString}:${minutesString}`;
 }

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -33,15 +33,13 @@ export function formattedTime(
 }
 
 export function numberToUTCOffset(offset: number): string {
-  const offsetHours = Math.floor(offset);
-  const offsetMinutes = Math.round((offset - offsetHours) * 60);
+  const absoluteOffset = Math.abs(offset);
+  const offsetHours = Math.floor(absoluteOffset);
+  const offsetMinutes = Math.round((absoluteOffset - offsetHours) * 60);
 
   const sign = offset >= 0 ? "+" : "-";
+  const format = (value: number) => value.toString().padStart(2, "0");
 
-  const format = (value: number) => Math.abs(value).toString().padStart(2, "0");
-
-  const hoursString = format(offsetHours);
-  const minutesString = format(offsetMinutes);
-
-  return `UTC${sign}${hoursString}:${minutesString}`;
+  return `UTC${sign}${format(offsetHours)}:${format(offsetMinutes)}`;
 }
+

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -31,3 +31,15 @@ export function formattedTime(
     .toFormat(timeFormat === "12" ? HOUR_FORMAT_12 : HOUR_FORMAT, { locale })
     .toLowerCase();
 }
+
+export function numberToTimezoneOffset(offset: number): string {
+  const offsetHours = Math.floor(offset);
+  const offsetMinutes = Math.round((offset - offsetHours) * 60);
+
+  const sign = offset >= 0 ? "+" : "-";
+
+  const hoursString = Math.abs(offsetHours).toString().padStart(2, "0");
+  const minutesString = Math.abs(offsetMinutes).toString().padStart(2, "0");
+
+  return `UTC${sign}${hoursString}:${minutesString}`;
+}


### PR DESCRIPTION
Vakit verisi içerisindeki `GreenwichOrtalamaZamani` değeri kullanılarak seçili şehrin saat dilimi ayarlandı.

`[{ "Aksam": "17:58", "AyinSekliURL": "...", "GreenwichOrtalamaZamani": -7, ... }]`

Böylece, saat dilimi farklı olan bir şehir seçildiğinde, "geçerli namaz" bilgisi doğru şekilde gösterildi.

Fix: #73 
