### PR TITLE
fix: updated api url in settings

### DIFF
--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -164,7 +164,7 @@ export default function Settings() {
           >
             <Box className="text-sm">
               <Box.BoxLink
-                href="https://ezanvakti.herokuapp.com"
+                href="https://ezanvakti.emushaf.net/"
                 target="_blank"
               >
                 <p className="text-pretty mr-10">


### PR DESCRIPTION
Ayarlar sayfasindaki eski url guncellendi.

![Screenshot 2025-02-14 at 17 53 50](https://github.com/user-attachments/assets/104bb377-7b39-484f-95ec-cc53963f5138)
